### PR TITLE
Adds foods show route and tests. Includes sad path test for bad entry.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
   "development": {
-    "username": "bp",
+    "username": "jamescape",
     "password": null,
     "database": "caloriecombs_development",
     "host": "127.0.0.1",
@@ -8,7 +8,7 @@
     "operatorsAliases": false
   },
   "test": {
-    "username": "bp",
+    "username": "jamescape",
     "password": null,
     "database": "caloriecombs_test",
     "host": "127.0.0.1",
@@ -16,7 +16,7 @@
     "operatorsAliases": false
   },
   "production": {
-    "username": "bp",
+    "username": "jamescape",
     "password": null,
     "database": "caloriecombs_production",
     "host": "127.0.0.1",

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -15,4 +15,21 @@ router.get("/", function(req, res, next) {
     });
 });
 
+/* GET a single food by :id */
+router.get("/:id", function(req, res, next) {
+  Food.findOne({
+    where: {
+      id: req.params.id
+    }
+  })
+  .then(food => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(200).send(JSON.stringify(food));
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(500).send({error})
+  });
+});
+
 module.exports = router;

--- a/spec/api/v1/foods.spec.js
+++ b/spec/api/v1/foods.spec.js
@@ -72,4 +72,52 @@ describe('Foods API', () => {
       )
     })
   })
+
+  test('Test GET /api/v1/foods/:id path', async () => {
+    let food_1 = await Food.create(
+      {
+      name: 'banana',
+      calories: 150
+    });
+
+    let food_3 = await Food.create(
+      {
+      name: 'salmon',
+      calories: 175
+    });
+
+    return request(app).get(`/api/v1/foods/${food_3.id}`)
+    .then(response => {
+      expect(response.status).toBe(200),
+      expect(response.body).toStrictEqual(
+        {
+          "calories": food_3.calories,
+          "createdAt": `${food_3.createdAt.toISOString()}`,
+          "id": food_3.id,
+          "name": food_3.name,
+          "updatedAt": `${food_3.updatedAt.toISOString()}`
+        }
+      )
+    })
+  })
+
+  test('Test catch GET /api/v1/foods/:id path', async () => {
+    let food_1 = await Food.create(
+      {
+      name: 'cake',
+      calories: 350
+    });
+
+    let food_3 = await Food.create(
+      {
+      name: 'donut',
+      calories: 185
+    });
+
+    return request(app).get(`/api/v1/foods/a`)
+    .then(response => {
+      expect(response.status).toBe(500),
+      expect(Object.keys(response.body)).toEqual(["error"]);
+    })
+  })
 })

--- a/spec/models/food.spec.js
+++ b/spec/models/food.spec.js
@@ -37,7 +37,6 @@ describe('model test', () => {
       calories: -100
     })
     .catch(food => {
-      console.log(food);
       expect(food.name).toBe("SequelizeUniqueConstraintError");
     });
   });
@@ -48,7 +47,6 @@ describe('model test', () => {
       calories: 0
     })
     .then(food => {
-      console.log(food);
       expect(food.calories).toBe(0);
     })
   });


### PR DESCRIPTION
## What functionality does this accomplish?
Closes Story #2 

**Description:**
A GET request to `/api/v1/foods/:id` will return the food with the requested id. 
```
{
  name: 'donut',
  calories: 185
}
```

## What did you struggle on to complete?
No issues - the foods index Story #1 served as a nice template.


## Current Test Suite:
### Test Coverage Percentage: 93.65%
- [ ] No Tests have been changed
- [x] Some Tests have been changed: Testing foods show and foods show sad path.
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code (please explain):

