### PR TITLE
Creates a new food when POST request to `api/v1foods` with food["name"] and food["calories"]

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
   "development": {
-    "username": "jamescape",
+    "username": "bp",
     "password": null,
     "database": "caloriecombs_development",
     "host": "127.0.0.1",
@@ -8,7 +8,7 @@
     "operatorsAliases": false
   },
   "test": {
-    "username": "jamescape",
+    "username": "bp",
     "password": null,
     "database": "caloriecombs_test",
     "host": "127.0.0.1",
@@ -16,7 +16,7 @@
     "operatorsAliases": false
   },
   "production": {
-    "username": "jamescape",
+    "username": "bp",
     "password": null,
     "database": "caloriecombs_production",
     "host": "127.0.0.1",

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -32,4 +32,24 @@ router.get("/:id", function(req, res, next) {
   });
 });
 
+/* POST to create a food */
+router.post("/", (req, res) => {
+  if (req.body.food.name && req.body.food.calories) {
+    Food.create({
+      name: req.body.food.name,
+      calories: req.body.food.calories
+    })
+    .then(food => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(201).send(JSON.stringify(food));
+    })
+    .catch(error => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(500).send({error})
+    });
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(400).send(JSON.stringify({error: "Please provide a food with a name and calories."}));
+  }
+})
 module.exports = router;

--- a/spec/api/v1/foods.spec.js
+++ b/spec/api/v1/foods.spec.js
@@ -120,4 +120,71 @@ describe('Foods API', () => {
       expect(Object.keys(response.body)).toEqual(["error"]);
     })
   })
+
+  test('Test POST /api/v1/foods/ path to create food', () => {
+    let food_new = {
+      food: {
+        name: "carrot",
+        calories: 20
+      }
+    }
+    return request(app).post(`/api/v1/foods`)
+    .send(food_new)
+    .then(response => {
+      expect(response.status).toBe(201),
+      expect.objectContaining({ food: expect.objectContaining({
+        name: expect.any(String),
+        calories: expect.any(Number)
+      })})
+    })
+  })
+
+  test("Test POST /api/v1/foods/ path doesn't create food if name missing", () => {
+    let food_new = {
+      food: {
+        name: null,
+        calories: 20
+      }
+    }
+    return request(app).post(`/api/v1/foods`)
+    .send(food_new)
+    .then(response => {
+      expect(response.status).toBe(400),
+      expect(Object.keys(response.body)).toEqual(["error"]);
+    })
+  })
+
+  test("Test POST /api/v1/foods/ path doesn't create food if calories missing", () => {
+    let food_new = {
+      food: {
+        name: "Spinach",
+        calories: null
+      }
+    }
+    return request(app).post(`/api/v1/foods`)
+    .send(food_new)
+    .then(response => {
+      expect(response.status).toBe(400),
+      expect(Object.keys(response.body)).toEqual(["error"]);
+    })
+  })
+
+  test("Test it doesn't create food if it already exists", async () => {
+    await Food.create({
+      name: "Spinach",
+      calories: 10
+    })
+    let food_new = {
+      food: {
+        name: "Spinach",
+        calories: 10
+      }
+    }
+    return request(app).post(`/api/v1/foods`)
+    .send(food_new)
+    .then(response => {
+      expect(response.status).toBe(500),
+      expect(Object.keys(response.body)).toEqual(["error"]);
+    })
+  })
 })


### PR DESCRIPTION
## What functionality does this accomplish?
Adds ability to POST to  with a food object containing a name and calories and create a food object that's saved in the DB
Closes #3 

**Description:**
`api/v1/foods` receives a POST request with a food object
```
{
"food": {
   "name": "example",
   "calories": 11111
    }
}
```

and creates a record in the DB and returns the food. Sad paths tested for not sending a name, not sending calories, or sending a food that's already in the DB.

## What did you struggle on to complete?
Testing the sad paths and getting the POST request to go through on the local server through Postman. Figured out the best way to do it in Postman is to send it in the body using the raw option with `JSON(application/json)` selected.

## Current Test Suite: Jest
### Test Coverage Percentage: 94.44%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain):

## Helpful Resources:
* Resource link AND small description of info gathered/learned
