### PR TITLE
Enables post request to add a food to a meal and tests happy/sad paths

### DIFF
--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -4,7 +4,6 @@ var Food = require('../../../models').Food;
 var Meal = require('../../../models').Meal;
 
 /* GET all meals */
-
 router.get('/', (request, response) => {
   return Meal.findAll({
     include: Food
@@ -16,6 +15,44 @@ router.get('/', (request, response) => {
   .catch(error => {
     response.setHeader('Content-Type', 'application/json');
     response.status(500).send({ error });
+  })
+})
+
+/* POST adds a food to a meal */
+router.post('/:meal_id/foods/:id', (request, response) => {
+  return Meal.findOne({
+    include: Food,
+    where: {
+      id: request.params["meal_id"]
+    }
+  })
+  .then(meal => {
+    return Food.findOne({
+      where: {
+        id: request.params["id"]
+      }
+    })
+    .then(food => {
+      return meal.hasFood(food).then(result => {
+        if (result == true) {
+          response.setHeader('Content-Type', 'application/json');
+          response.status(500).send({ error: 'Meal already has that food' });
+        } else {
+          meal.addFood(food)
+          response.setHeader('Content-Type', 'application/json');
+          response.status(200).send(JSON.stringify({message: `Successfully added ${food.name} to ${meal.name}`}));
+        }
+      })
+    })
+    .catch(error => {
+      if (meal == null) {
+        response.setHeader('Content-Type', 'application/json');
+        response.status(500).send({ error: 'Meal not found' });
+      } else {
+        response.setHeader('Content-Type', 'application/json');
+        response.status(500).send({ error: 'Food not found' });
+      }
+    })
   })
 })
 

--- a/spec/helper/testCleanUp.js
+++ b/spec/helper/testCleanUp.js
@@ -1,7 +1,9 @@
 var Food = require('../../models').Food;
 var Meal = require('../../models').Meal;
+var MealFood = require('../../models').MealFood;
 
 module.exports = async function cleanup() {
   await Food.destroy({ where: {} });
   await Meal.destroy({ where: {} });
+  await MealFood.destroy({ where: {} });
 }


### PR DESCRIPTION
## What functionality does this accomplish?
Closes Story #8 

**Description:**
This PR enables a post request to add a food to a meal:
`api/v1/meals/:meal_id/foods/:id`

## What did you struggle on to complete?
This was my first time using `addResource()`:
```
meal.addFood(food)
```


## Current Test Suite:
### Test Coverage Percentage: 95.42%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain):

## Helpful Resources:
* The addUser section of the [Sequelize docs](https://sequelize.readthedocs.io/en/latest/docs/associations/) guided me through adding a food to a meal.
